### PR TITLE
Add Settings Tab from Existing Profiles Tab (1/2)

### DIFF
--- a/StudyMeets/App.js
+++ b/StudyMeets/App.js
@@ -5,11 +5,11 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Login from './app/screens/Login';
 import Explore from './app/screens/Explore';
-import Profile from './app/screens/Profile';
+import SettingsNavigation from './app/screens/SettingsNavigation';
 import MyGroups from './app/screens/MyGroups';
 import People from './app/screens/People';
 import CreateProfile from './app/screens/CreateProfile';
-import { UserCircle2, Search, Users, LayoutGrid } from 'lucide-react-native';
+import { Settings, Search, Users, LayoutGrid } from 'lucide-react-native';
 
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -20,7 +20,7 @@ const MainTabs = () => {
       <Tab.Screen name="Explore" component={Explore} options={{headerShown: false, tabBarIcon: ({ color, size }) => <Search color={color} size={size} />}} />
       <Tab.Screen name="MyGroups" component={MyGroups} options={{headerShown: false, tabBarIcon: ({ color, size }) => <LayoutGrid color={color} size={size} />}}/>
       <Tab.Screen name="People" component={People} options={{headerShown: false, tabBarIcon: ({ color, size }) => <Users color={color} size={size} />}}/>
-      <Tab.Screen name="Profile" component={Profile} options={{headerShown: false, tabBarIcon: ({ color, size }) => <UserCircle2 color={color} size={size} /> }} />
+      <Tab.Screen name="Settings" component={SettingsNavigation} options={{headerShown: false, tabBarIcon: ({ color, size }) => <Settings color={color} size={size} /> }} />
     </Tab.Navigator>
   );
 };

--- a/StudyMeets/app/screens/MyGroups.js
+++ b/StudyMeets/app/screens/MyGroups.js
@@ -5,6 +5,7 @@ import { collection, query, where, onSnapshot, getDocs, doc, deleteDoc } from 'f
 import EditPost from './EditPost';
 import GroupCard from './GroupCard';
 import { Text } from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 const MyGroups = () => {
   const [createdPosts, setCreatedPosts] = useState([]);
@@ -99,7 +100,7 @@ const MyGroups = () => {
   };
 
   return (
-    <View style={{ flex: 1, padding: 10, paddingTop: 30 }}>
+    <SafeAreaView style={{ flex: 1, padding: 10, paddingTop: 30 }}>
       <Text variant="titleLarge" style={{ marginVertical: 10 }}>Groups You Created</Text>
       <FlatList
         data={createdPosts}
@@ -135,7 +136,7 @@ const MyGroups = () => {
           postId={selectedPostId} 
         />
       )}
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/StudyMeets/app/screens/MyProfile.js
+++ b/StudyMeets/app/screens/MyProfile.js
@@ -80,7 +80,7 @@ const MyProfile = ({ imageUri, setImageUri }) => {
       await uploadBytes(imageRef, blob);
 
       const downloadURL = await getDownloadURL(imageRef);
-      await updateDoc(doc(firestore, 'users', user.uid), { photoURL: downloadURL });
+      await updateDoc(doc(firestore, 'users', user.uid), { profileImageURL: downloadURL });
       setImageUri(downloadURL);
 
       blob.close();

--- a/StudyMeets/app/screens/MyProfile.js
+++ b/StudyMeets/app/screens/MyProfile.js
@@ -9,10 +9,9 @@ import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { useNavigation } from '@react-navigation/native';
 import { signOut, sendPasswordResetEmail } from 'firebase/auth';
 
-const Profile = () => {
+const MyProfile = ({ imageUri, setImageUri }) => {
   const [user, setUser] = useState(null);
   const [username, setUsername] = useState(null);
-  const [imageUri, setImageUri] = useState(null);
   const [uploading, setUploading] = useState(false);
   const navigation = useNavigation();
   const storage = getStorage();
@@ -34,7 +33,6 @@ const Profile = () => {
         const userDoc = await getDoc(doc(firestore, 'users', currentUser.uid));
         if (userDoc.exists()) {
           setUsername(userDoc.data()?.username || 'No username found');
-          setImageUri(userDoc.data()?.photoURL || placeholderImage);
         } else {
           console.log('No user document found!');
         }
@@ -60,14 +58,9 @@ const Profile = () => {
       quality: 1,
     });
 
-    console.log("ImagePicker result:", result);
-
     if (!result.canceled && result.assets && result.assets.length > 0) {
       const selectedUri = result.assets[0].uri;
-      console.log("Selected Image URI:", selectedUri);
       await uploadImage(selectedUri);
-    } else {
-      console.log("Image selection was canceled or failed");
     }
   };
 
@@ -77,8 +70,6 @@ const Profile = () => {
     setUploading(true);
     try {
       if (!user) throw new Error("User not authenticated.");
-
-      console.log("Uploading image from URI:", uri);
 
       const response = await fetch(uri);
       if (!response.ok) throw new Error("Failed to fetch image from URI");
@@ -107,11 +98,8 @@ const Profile = () => {
         await sendPasswordResetEmail(auth, user.email);
         Alert.alert("Password Reset", "Check your email for password reset instructions.");
       } catch (error) {
-        console.error("Error sending password reset email:", error);
         Alert.alert("Error", "Unable to send password reset email.");
       }
-    } else {
-      Alert.alert("Error", "No user email found.");
     }
   };
 
@@ -128,18 +116,16 @@ const Profile = () => {
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20, paddingTop: 30 }}>
       {user ? (
         <>
-          {/* Increase Avatar Image size */}
           <Avatar.Image
-            size={120} // Larger size for the profile image
+            size={120}
             source={{ uri: imageUri || placeholderImage }}
           />
           <PaperButton
             mode="text"
             onPress={pickImage}
             loading={uploading}
-            style={{ marginVertical: 10, width: 200, paddingVertical: 0 }} // Smaller button size
-            
             disabled={uploading}
+            style={{ marginVertical: 10, width: 200 }}
           >
             {uploading ? "Uploading..." : "Change Profile Image"}
           </PaperButton>
@@ -171,4 +157,4 @@ const Profile = () => {
   );
 };
 
-export default Profile;
+export default MyProfile;

--- a/StudyMeets/app/screens/People.js
+++ b/StudyMeets/app/screens/People.js
@@ -1,10 +1,15 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Alert } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+import React, { useEffect, useState } from 'react';
+import { auth } from '../../firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import { firestore } from '../../firebase';
+import { Avatar } from 'react-native-paper';
+import MyProfile from './MyProfile';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 const Tab = createMaterialTopTabNavigator();
 
-// Individual Screens
 const FriendsScreen = () => (
   <View style={styles.tabContainer}>
     <Text>Friends</Text>
@@ -23,25 +28,66 @@ const FollowersScreen = () => (
   </View>
 );
 
-// Main People Component
 const People = () => {
+  const [user, setUser] = useState(null);
+  const [imageUri, setImageUri] = useState(null);
+  const placeholderImage = 'https://via.placeholder.com/80';
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      const currentUser = auth.currentUser;
+      if (!currentUser) {
+        Alert.alert("Error", "User not found. Please log in again.");
+        navigation.navigate('Login');
+        return;
+      }
+
+      setUser(currentUser);
+
+      try {
+        const userDoc = await getDoc(doc(firestore, 'users', currentUser.uid));
+        if (userDoc.exists()) {
+          setImageUri(userDoc.data()?.photoURL || placeholderImage);
+        } else {
+          console.log('No user document found!');
+        }
+      } catch (error) {
+        console.error("Error fetching user info:", error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
   return (
-    <View style={{ flex: 1, paddingTop: 20 }}>
+    <SafeAreaView style={{ flex: 1 }}>
       <Tab.Navigator
         screenOptions={{
           tabBarActiveTintColor: '#000',
           tabBarIndicatorStyle: { backgroundColor: '#000' },
-          tabBarLabelStyle: { fontSize: 18 },
-          tabBarStyle: { backgroundColor: '#f5f5f5', height: 50 },
+          tabBarLabelStyle: { fontSize: 16 },
+          tabBarStyle: { backgroundColor: '#f5f5f5' },
+          tabBarItemStyle: { margin: 0, padding: 5 }
         }}
       >
         <Tab.Screen name="Friends" component={FriendsScreen} options={{ headerShown: false }} />
         <Tab.Screen name="Following" component={FollowingScreen} options={{ headerShown: false }} />
         <Tab.Screen name="Followers" component={FollowersScreen} options={{ headerShown: false }} />
+        <Tab.Screen
+          name="MyProfile"
+          options={{ headerShown: false, tabBarLabel: () => null,
+            tabBarIcon: ({ color, size }) => (
+              <Avatar.Image size={50} source={{ uri: imageUri || placeholderImage }} />
+            ),
+          }}>
+          {() => <MyProfile imageUri={imageUri} setImageUri={setImageUri} />}
+        </Tab.Screen>
       </Tab.Navigator>
-    </View>
+    </SafeAreaView>
   );
 };
+
+export default People;
 
 const styles = StyleSheet.create({
   tabContainer: {
@@ -51,5 +97,3 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
 });
-
-export default People;

--- a/StudyMeets/app/screens/People.js
+++ b/StudyMeets/app/screens/People.js
@@ -47,7 +47,7 @@ const People = () => {
       try {
         const userDoc = await getDoc(doc(firestore, 'users', currentUser.uid));
         if (userDoc.exists()) {
-          setImageUri(userDoc.data()?.photoURL || placeholderImage);
+          setImageUri(userDoc.data()?.profileImageURL || placeholderImage);
         } else {
           console.log('No user document found!');
         }

--- a/StudyMeets/app/screens/SettingsNavigation.js
+++ b/StudyMeets/app/screens/SettingsNavigation.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import SettingsTab from './SettingsTab';
+
+const Stack = createNativeStackNavigator();
+
+const NotificationsScreen = () => (
+    <View style={styles.tabContainer}>
+        <Text>notifications</Text>
+    </View>
+);
+
+const NotificationSettingsScreen = () => (
+    <View style={styles.tabContainer}>
+        <Text>notification settings</Text>
+    </View>
+);
+
+const ProfilePrivacyScreen = () => (
+    <View style={styles.tabContainer}>
+        <Text>profile privacy settings</Text>
+    </View>
+);
+
+const GeneralScreen = () => (
+    <View style={styles.tabContainer}>
+        <Text>general settings</Text>
+    </View>
+);
+
+const SettingsNavigation = () => {
+
+    return (
+        <Stack.Navigator initialRouteName="SettingsTab">
+            <Stack.Screen name="SettingsTab" component={SettingsTab} options={{ headerShown: false }}/>
+            <Stack.Screen name="Notifications" component={NotificationsScreen}/>
+            <Stack.Screen name="Notification Settings" component={NotificationSettingsScreen}/>
+            <Stack.Screen name="Profile Privacy Settings" component={ProfilePrivacyScreen}/>
+            <Stack.Screen name="General Settings" component={GeneralScreen}/>
+        </Stack.Navigator>
+    )
+};
+
+export default SettingsNavigation;
+
+const styles = StyleSheet.create({
+    tabContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: '#fff',
+    },
+  });

--- a/StudyMeets/app/screens/SettingsTab.js
+++ b/StudyMeets/app/screens/SettingsTab.js
@@ -1,0 +1,74 @@
+import React from "react";
+import { View, TouchableOpacity, Text, StyleSheet } from "react-native";
+import { useNavigation } from '@react-navigation/native';
+import { Mail } from "lucide-react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const SettingsTab = () => {
+    
+    const navigation = useNavigation();
+
+    return (
+        <SafeAreaView style={styles.container}>
+
+          <Text style={styles.title}>Settings</Text>
+
+          <TouchableOpacity style={styles.mailIcon} onPress={() => navigation.navigate('Notifications')}>
+            <Mail size={40} color="black" />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.settingOption}
+            onPress={() => navigation.navigate('Notification Settings')}>
+            <Text style={styles.settingText}>Notification Settings</Text>
+          </TouchableOpacity>
+    
+          <TouchableOpacity
+            style={styles.settingOption}
+            onPress={() => navigation.navigate('Profile Privacy Settings')}>
+            <Text style={styles.settingText}>Profile Privacy Settings</Text>
+          </TouchableOpacity>
+    
+          <TouchableOpacity
+            style={styles.settingOption}
+            onPress={() => navigation.navigate('General Settings')}>
+            <Text style={styles.settingText}>General Settings</Text>
+          </TouchableOpacity>
+
+        </SafeAreaView>
+    );
+};
+    
+export default SettingsTab;
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        paddingTop: 20,
+        paddingHorizontal: 15,
+    },
+    title: {
+        fontSize: 30,
+        fontWeight: 'bold',
+        marginBottom: 20,
+    },
+        mailIcon: {
+        position: 'absolute',
+        top: 45,
+        right: 15,
+    },
+    settingOption: {
+        backgroundColor: '#fff',
+        padding: 15,
+        marginVertical: 10,
+        borderRadius: 10,
+        borderWidth: 1,
+        borderColor: '#ddd',
+        alignItems: 'center',
+    },
+    settingText: {
+        fontSize: 16,
+        color: '#000',
+    },
+});
+    


### PR DESCRIPTION
Closes #85

Implementations:
- moved things on profile tab to a sub tab on people main tab denoted by your profile picture
- changed profile on main app tab to a settings tab
- implemented skeleton settings navigation to app notifications, notification settings, profile privacy settings, general settings
<img src="https://github.com/user-attachments/assets/7d6dabcc-07ac-4140-97aa-899ea09b5093" alt="First image" width="300" />
<img src="https://github.com/user-attachments/assets/e48d72d4-8a2c-4e29-8854-7e581d9f5902" alt="Second image" width="300" />

